### PR TITLE
Show dictionary/object keys in sorted order rather than random order

### DIFF
--- a/gtkjsonview.py
+++ b/gtkjsonview.py
@@ -78,7 +78,7 @@ def walk_tree(data, model, parent = None):
   if isinstance(data, list):
     add_item('', data, model, parent)
   elif isinstance(data, dict):
-    for key in data:
+    for key in sorted(data):
       add_item(key, data[key], model, parent)
   else:
     add_item('', data, model, parent)


### PR DESCRIPTION
This will sort all the object (dictionary) keys alphabetically, rather than displaying them in the apparent random order used by the Python internal dictionary hashing.