### PR TITLE
Show json scalar values (null, float, etc) and properly XML-escape strings

### DIFF
--- a/gtkjsonview.py
+++ b/gtkjsonview.py
@@ -81,7 +81,8 @@ def add_item(key, data, model, parent = None):
     model.append(parent, ['<span foreground="'+color_key+'">"' + key + '"</span>' +
                           '  <b>:</b> <span foreground="'+color_integer+'">' + str(data) + '</span>'])
   else:
-    model.append(parent, [str(data)])
+    model.append(parent, ['<span foreground="'+color_key+'">"' + key + '"</span>' +
+                          '  <b>:</b> <span foreground="'+color_integer+'">' + repr(data) + '</span>'])
 
 def walk_tree(data, model, parent = None):
   if isinstance(data, list):

--- a/gtkjsonview.py
+++ b/gtkjsonview.py
@@ -53,6 +53,11 @@ def add_item(key, data, model, parent = None):
       add_item('', data[index], model, model.append(arr, ['<b><span foreground="'+color_type+'">'+'['+'</span></b><span foreground="'+color_integer+'">'
                                                           + str(index)
                                                           + '</span><b><span foreground="'+color_type+'">]</span></b>']))
+
+  elif data == None:
+    model.append(parent, ['<span foreground="'+color_key+'">"' + key + '"</span>' +
+                          '  <b>:</b> <span foreground="'+color_integer+'">' + 'null' + '</span>'])
+
   elif isinstance(data, bool):
     model.append(parent, ['<span foreground="'+color_key+'">"' + key + '"</span>' +
                           '  <b>:</b> <span foreground="'+color_integer+'">' + str(data).lower() + '</span>'])

--- a/gtkjsonview.py
+++ b/gtkjsonview.py
@@ -53,6 +53,10 @@ def add_item(key, data, model, parent = None):
       add_item('', data[index], model, model.append(arr, ['<b><span foreground="'+color_type+'">'+'['+'</span></b><span foreground="'+color_integer+'">'
                                                           + str(index)
                                                           + '</span><b><span foreground="'+color_type+'">]</span></b>']))
+  elif isinstance(data, bool):
+    model.append(parent, ['<span foreground="'+color_key+'">"' + key + '"</span>' +
+                          '  <b>:</b> <span foreground="'+color_integer+'">' + str(data).lower() + '</span>'])
+
   elif isinstance(data, str):
     if len(data) > 256:
       data = data[0:255] + "..."

--- a/gtkjsonview.py
+++ b/gtkjsonview.py
@@ -42,31 +42,31 @@ else:
 
 def add_item(key, data, model, parent = None):
   if isinstance(data, dict):
-    if len(key):
-      obj = model.append(parent, ['<span foreground="'+color_object+'">'
-                                  + escape(key) + '</span>' +
+    if key is not None:
+      obj = model.append(parent, ['<span foreground="'+color_object+'">"'
+                                  + escape(key) + '"</span>' +
                                   ' <span foreground="'+color_type+'"><b>{}</b></span>'])
       walk_tree(data, model, obj)
     else:
       walk_tree(data, model, parent)
   elif isinstance(data, list):
-    arr = model.append(parent, ['<span foreground="'+color_array+'">'+ escape(key) + '</span> '
+    arr = model.append(parent, ['<span foreground="'+color_array+'">"'+ ('' if key is None else escape(key)) + '"</span> '
                                 '<span foreground="'+color_type+'"><b>[]</b></span> ' +
                                 '<span foreground="'+color_integer+'">' + str(len(data)) + '</span>'])
     for index in range(0, len(data)):
-      add_item('', data[index], model, model.append(arr, ['<b><span foreground="'+color_type+'">'+'['+'</span></b><span foreground="'+color_integer+'">'
+      add_item(None, data[index], model, model.append(arr, ['<b><span foreground="'+color_type+'">'+'['+'</span></b><span foreground="'+color_integer+'">'
                                                           + str(index)
                                                           + '</span><b><span foreground="'+color_type+'">]</span></b>']))
 
   elif data == None:
-    if len(key):
+    if key is not None:
       model.append(parent, ['<span foreground="'+color_key+'">"' + escape(key) + '"</span>' +
                             '  <b>:</b> <span foreground="'+color_integer+'">' + 'null' + '</span>'])
     else:
       model.append(parent, ['<span foreground="'+color_integer+'">' + 'null' + '</span>'])
 
   elif isinstance(data, bool):
-    if len(key):
+    if key is not None:
       model.append(parent, ['<span foreground="'+color_key+'">"' + escape(key) + '"</span>' +
                             '  <b>:</b> <span foreground="'+color_integer+'">' + str(data).lower() + '</span>'])
     else:
@@ -75,27 +75,27 @@ def add_item(key, data, model, parent = None):
   elif isinstance(data, str):
     if len(data) > 256:
       data = data[0:255] + "..."
-      if len(key):
+      if key is not None:
         model.append(parent, ['<span foreground="'+color_key+'">"' + escape(key) + '"</span>' +
                             '<b>:</b> <span foreground="'+color_string+'">"' + escape(data) + '"</span>'])
       else:
         model.append(parent, ['<span foreground="'+color_string+'">"' + escape(data) + '"</span>'])
     else:
-      if len(key):
+      if key is not None:
         model.append(parent, ['<span foreground="'+color_key+'">"' + escape(key) + '"</span>' +
                             '  <b>:</b> <span foreground="'+color_string+'">"' + escape(data) + '"</span>'])
       else:
         model.append(parent, ['<span foreground="'+color_string+'">"' + escape(data) + '"</span>'])
 
   elif isinstance(data, int):
-    if len(key):
+    if key is not None:
       model.append(parent, ['<span foreground="'+color_key+'">"' + escape(key) + '"</span>' +
                             '  <b>:</b> <span foreground="'+color_integer+'">' + str(data) + '</span>'])
     else:
       model.append(parent, ['<span foreground="'+color_integer+'">' + str(data) + '</span>'])
 
   else:
-    if len(key):
+    if key is not None:
       model.append(parent, ['<span foreground="'+color_key+'">"' + escape(key) + '"</span>' +
                             '  <b>:</b> <span foreground="'+color_integer+'">' + escape(repr(data)) + '</span>'])
     else:
@@ -103,12 +103,12 @@ def add_item(key, data, model, parent = None):
 
 def walk_tree(data, model, parent = None):
   if isinstance(data, list):
-    add_item('', data, model, parent)
+    add_item(None, data, model, parent)
   elif isinstance(data, dict):
     for key in data:
       add_item(key, data[key], model, parent)
   else:
-    add_item('', data, model, parent)
+    add_item(None, data, model, parent)
 
 #return the json query given a path
 def to_jq(path, data):

--- a/gtkjsonview.py
+++ b/gtkjsonview.py
@@ -55,12 +55,18 @@ def add_item(key, data, model, parent = None):
                                                           + '</span><b><span foreground="'+color_type+'">]</span></b>']))
 
   elif data == None:
-    model.append(parent, ['<span foreground="'+color_key+'">"' + key + '"</span>' +
-                          '  <b>:</b> <span foreground="'+color_integer+'">' + 'null' + '</span>'])
+    if len(key):
+      model.append(parent, ['<span foreground="'+color_key+'">"' + key + '"</span>' +
+                            '  <b>:</b> <span foreground="'+color_integer+'">' + 'null' + '</span>'])
+    else:
+      model.append(parent, ['<span foreground="'+color_integer+'">' + 'null' + '</span>'])
 
   elif isinstance(data, bool):
-    model.append(parent, ['<span foreground="'+color_key+'">"' + key + '"</span>' +
-                          '  <b>:</b> <span foreground="'+color_integer+'">' + str(data).lower() + '</span>'])
+    if len(key):
+      model.append(parent, ['<span foreground="'+color_key+'">"' + key + '"</span>' +
+                            '  <b>:</b> <span foreground="'+color_integer+'">' + str(data).lower() + '</span>'])
+    else:
+      model.append(parent, ['<span foreground="'+color_integer+'">' + str(data).lower() + '</span>'])
 
   elif isinstance(data, str):
     if len(data) > 256:
@@ -78,11 +84,18 @@ def add_item(key, data, model, parent = None):
         model.append(parent, ['<span foreground="'+color_string+'">"' + data + '"</span>'])
 
   elif isinstance(data, int):
-    model.append(parent, ['<span foreground="'+color_key+'">"' + key + '"</span>' +
-                          '  <b>:</b> <span foreground="'+color_integer+'">' + str(data) + '</span>'])
+    if len(key):
+      model.append(parent, ['<span foreground="'+color_key+'">"' + key + '"</span>' +
+                            '  <b>:</b> <span foreground="'+color_integer+'">' + str(data) + '</span>'])
+    else:
+      model.append(parent, ['<span foreground="'+color_integer+'">' + str(data) + '</span>'])
+
   else:
-    model.append(parent, ['<span foreground="'+color_key+'">"' + key + '"</span>' +
-                          '  <b>:</b> <span foreground="'+color_integer+'">' + repr(data) + '</span>'])
+    if len(key):
+      model.append(parent, ['<span foreground="'+color_key+'">"' + key + '"</span>' +
+                            '  <b>:</b> <span foreground="'+color_integer+'">' + repr(data) + '</span>'])
+    else:
+      model.append(parent, [repr(data)])
 
 def walk_tree(data, model, parent = None):
   if isinstance(data, list):

--- a/gtkjsonview.py
+++ b/gtkjsonview.py
@@ -1,5 +1,9 @@
 import sys
 import os
+try:
+  from xml.sax.saxutils import escape
+except:
+  from cgi import escape
 import gi
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, Gdk
@@ -40,13 +44,13 @@ def add_item(key, data, model, parent = None):
   if isinstance(data, dict):
     if len(key):
       obj = model.append(parent, ['<span foreground="'+color_object+'">'
-                                  + str(key) + '</span>' +
+                                  + escape(key) + '</span>' +
                                   ' <span foreground="'+color_type+'"><b>{}</b></span>'])
       walk_tree(data, model, obj)
     else:
       walk_tree(data, model, parent)
   elif isinstance(data, list):
-    arr = model.append(parent, ['<span foreground="'+color_array+'">'+ key + '</span> '
+    arr = model.append(parent, ['<span foreground="'+color_array+'">'+ escape(key) + '</span> '
                                 '<span foreground="'+color_type+'"><b>[]</b></span> ' +
                                 '<span foreground="'+color_integer+'">' + str(len(data)) + '</span>'])
     for index in range(0, len(data)):
@@ -56,14 +60,14 @@ def add_item(key, data, model, parent = None):
 
   elif data == None:
     if len(key):
-      model.append(parent, ['<span foreground="'+color_key+'">"' + key + '"</span>' +
+      model.append(parent, ['<span foreground="'+color_key+'">"' + escape(key) + '"</span>' +
                             '  <b>:</b> <span foreground="'+color_integer+'">' + 'null' + '</span>'])
     else:
       model.append(parent, ['<span foreground="'+color_integer+'">' + 'null' + '</span>'])
 
   elif isinstance(data, bool):
     if len(key):
-      model.append(parent, ['<span foreground="'+color_key+'">"' + key + '"</span>' +
+      model.append(parent, ['<span foreground="'+color_key+'">"' + escape(key) + '"</span>' +
                             '  <b>:</b> <span foreground="'+color_integer+'">' + str(data).lower() + '</span>'])
     else:
       model.append(parent, ['<span foreground="'+color_integer+'">' + str(data).lower() + '</span>'])
@@ -72,30 +76,30 @@ def add_item(key, data, model, parent = None):
     if len(data) > 256:
       data = data[0:255] + "..."
       if len(key):
-        model.append(parent, ['<span foreground="'+color_key+'">"' + key + '"</span>' +
-                            '<b>:</b> <span foreground="'+color_string+'">"' + data + '"</span>'])
+        model.append(parent, ['<span foreground="'+color_key+'">"' + escape(key) + '"</span>' +
+                            '<b>:</b> <span foreground="'+color_string+'">"' + escape(data) + '"</span>'])
       else:
-        model.append(parent, ['<span foreground="'+color_string+'">"' + data + '"</span>'])
+        model.append(parent, ['<span foreground="'+color_string+'">"' + escape(data) + '"</span>'])
     else:
       if len(key):
-        model.append(parent, ['<span foreground="'+color_key+'">"' + key + '"</span>' +
-                            '  <b>:</b> <span foreground="'+color_string+'">"' + data + '"</span>'])
+        model.append(parent, ['<span foreground="'+color_key+'">"' + escape(key) + '"</span>' +
+                            '  <b>:</b> <span foreground="'+color_string+'">"' + escape(data) + '"</span>'])
       else:
-        model.append(parent, ['<span foreground="'+color_string+'">"' + data + '"</span>'])
+        model.append(parent, ['<span foreground="'+color_string+'">"' + escape(data) + '"</span>'])
 
   elif isinstance(data, int):
     if len(key):
-      model.append(parent, ['<span foreground="'+color_key+'">"' + key + '"</span>' +
+      model.append(parent, ['<span foreground="'+color_key+'">"' + escape(key) + '"</span>' +
                             '  <b>:</b> <span foreground="'+color_integer+'">' + str(data) + '</span>'])
     else:
       model.append(parent, ['<span foreground="'+color_integer+'">' + str(data) + '</span>'])
 
   else:
     if len(key):
-      model.append(parent, ['<span foreground="'+color_key+'">"' + key + '"</span>' +
-                            '  <b>:</b> <span foreground="'+color_integer+'">' + repr(data) + '</span>'])
+      model.append(parent, ['<span foreground="'+color_key+'">"' + escape(key) + '"</span>' +
+                            '  <b>:</b> <span foreground="'+color_integer+'">' + escape(repr(data)) + '</span>'])
     else:
-      model.append(parent, [repr(data)])
+      model.append(parent, [escape(repr(data))])
 
 def walk_tree(data, model, parent = None):
   if isinstance(data, list):


### PR DESCRIPTION
Generally fix the display of JSON values.

- Show scalar values None, True, and False as the JSON keywords null, true, and false
- XML-escape all string values, so they don't get interpreted by gtk
- Show lone JSON values which are not inside an array or dictionary
- Use Python repr() to display types not specifically handled; this fixes Float values
- Handle and properly show dictionary keys which are empty zero-length strings

This could overlap or be an alternative to pull request #7 but handles things differently, as well as ensuring proper XML escaping.