### PR TITLE
Fix JSON path expression bug introduced by dictionary sorting

### DIFF
--- a/gtkjsonview.py
+++ b/gtkjsonview.py
@@ -96,7 +96,7 @@ def to_jq(path, data):
 
   for index in indices:
     if isinstance(data, dict):
-      key = (list(data)[index])
+      key = (list(sorted(data))[index])
       jq += '.' + key
       data = data[key]
       if isinstance(data, list):


### PR DESCRIPTION
This fixes pull request #8 which introduced a bug in commit 172f3264b4b60d5c6d2c836b8b8a072577662b7c

When iterating over a dictionary to figure out which item is the selected one in the tree, the iteration must be done in the same key order as that used for displaying the tree.