### PR TITLE
Apply bracket-notation for JSON path/query keys which are not simple words

### DIFF
--- a/gtkjsonview.py
+++ b/gtkjsonview.py
@@ -1,6 +1,7 @@
 import sys
 import os
 import gi
+import re
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, Gdk
 try:
@@ -83,6 +84,11 @@ def walk_tree(data, model, parent = None):
   else:
     add_item('', data, model, parent)
 
+# Key/property names which match this regex syntax may appear in a
+# JSON path in their original unquoted form in dotted notation.
+# Otherwise they must use the quoted-bracked notation.
+jsonpath_unquoted_property_regex = re.compile(r"^[a-zA-Z][a-zA-Z0-9_]*$")
+
 #return the json query given a path
 def to_jq(path, data):
   indices = path.get_indices()
@@ -97,7 +103,10 @@ def to_jq(path, data):
   for index in indices:
     if isinstance(data, dict):
       key = (list(data)[index])
-      jq += '.' + key
+      if len(key)==0 or not jsonpath_unquoted_property_regex.match(key):
+        jq += '[\'{}\']'.format(key) # bracket notation (no initial dot)
+      else:
+        jq += '.' + key # dotted notation
       data = data[key]
       if isinstance(data, list):
         jq += '[]'


### PR DESCRIPTION
Try to construct properly "quoted" JSON Path (query) strings for dictionary keys which are not just simple words.  There is a special bracket notation which should be used rather than the dotted notation.

See http://goessner.net/articles/JsonPath/ among others.

The spec isn't completely clear when the bracket notation must be used, but most implementations seem to only allow the unquoted dotted form when the key starts with at least one ASCII letter and then only contains letters, digits, or non-special characters.

Note that even with the bracket notation, there is no specified way to quote a key which contains an apostrophe.  This patch doesn't try to handle that case.
