### PR TITLE
Refactor out to separate view and store

### DIFF
--- a/gtkjsonview.py
+++ b/gtkjsonview.py
@@ -11,6 +11,19 @@ Classes
 
 JSONViewerWindow()
     The window.
+
+JSONTreeStore()
+    A store that can be used with JSONTreeView. Derived from Gtk.TreeStore.
+
+JSONTreeView()
+    A widget for displaying JSON. Derived from Gtk.TreeView.
+
+
+Functions
+---------
+
+to_jq(path, data)
+    Return the JSON query given a path.
 """
 
 import numbers
@@ -27,116 +40,13 @@ try:
 except ImportError:
     import simplejson as json
 
-raw_data = ""
-from_stdin = not (sys.stdin.isatty())
-
-if len(sys.argv) == 2:
-    raw_data = open(sys.argv[1]).read().strip()
-elif from_stdin:
-    raw_data = sys.stdin.read().strip()
-
-if raw_data and raw_data[0] == "(" and raw_data[-1] == ")":
-    raw_data = raw_data[1:-1]
-
-is_dark = Gtk.Settings.get_default().get_property("gtk-application-prefer-dark-theme")
-if is_dark:
-    color_array = "#f9f06b"  # Yellow
-    color_type = "#ffbe6f"  # Orange
-    color_string = "#dc8add"  # Purple
-    color_number = "#f66151"  # Red
-    color_object = "#99c1f1"  # Blue
-    color_key = "#8ff0a4"  # Green
-else:
-    color_array = "#e5a50a"  # Yellow
-    color_type = "#c64600"  # Orange
-    color_string = "#613583"  # Purple
-    color_number = "#a51d2d"  # Red
-    color_object = "#1a5fb4"  # Blue
-    color_key = "#26a269"  # Green
-
-
-def format_item(color_key, color_value, key, value):
-    if key is None:
-    return '<span foreground="{}">[…]</span> <span foreground="{}">{}</span>'.format(
-        color_key, color_value, value
-    )
-    return '<span foreground="{}">"{}"</span>: <span foreground="{}">{}</span>'.format(
-        color_key, key, color_value, value
-    )
-
-
-def span(color, value):
-    return '<span foreground="{}">"{}"</span>'.format(color, value)
-
-
-def add_item(key, data, model, parent=None):
-    if isinstance(data, dict):
-        if key is not None:
-            obj = model.append(
-                parent, [format_item(color_object, color_type, str(key), "{}")]
-            )
-            walk_tree(data, model, obj)
-        else:
-            walk_tree(data, model, parent)
-    elif isinstance(data, list):
-        item = format_item(color_array, color_number, key, str(len(data)))
-        arr = model.append(parent, [item])
-        for index in range(0, len(data)):
-            item = '<b><span foreground="{}">[</span></b><span foreground="{}">{}</span><b><span foreground="{}">]</span></b>'.format(
-                color_type, color_number, str(index), color_type
-            )
-            add_item(None, data[index], model, model.append(arr, [item]))
-    elif isinstance(data, str):
-        if len(data) > 256:
-            data = data[0:255] + " <i>...</i> "
-            if key is not None:
-                item = format_item(color_key, color_string, key, f'"{data}"')
-                model.append(parent, [item])
-            else:
-                item = span(color_string, data)
-                model.append(parent, [item])
-        else:
-            if key is not None:
-                item = format_item(color_key, color_string, key, f'"{data}"')
-                model.append(parent, [item])
-            else:
-                item = span(color_string, data)
-                model.append(parent, [item])
-
-    elif isinstance(data, numbers.Real):
-        item = format_item(color_key, color_number, key, str(data))
-        model.append(parent, [item])
-    elif data is None:
-        item = '<span foreground="{}">{}</span> <span foreground="{}"><i>{}</i></span>'.format(
-            color_key, key, color_type, "null"
-        )
-        model.append(parent, [item])
-    else:
-        print(
-            "Warning: do not know how to format {} of type {}".format(str(data)),
-            data.__class__.__name__,
-        )
-        model.append(parent, [repr(data)])
-
-
-def walk_tree(data, model, parent=None):
-    if isinstance(data, list):
-        add_item(None, data, model, parent)
-    elif isinstance(data, dict):
-        for key in sorted(data):
-            add_item(key, data[key], model, parent)
-    else:
-        add_item(None, data, model, parent)
-
-
 # Key/property names which match this regex syntax may appear in a
 # JSON path in their original unquoted form in dotted notation.
 # Otherwise they must use the quoted-bracked notation.
 jsonpath_unquoted_property_regex = re.compile(r"^[a-zA-Z][a-zA-Z0-9_]*$")
 
-
-# return the JSON query given a path
-def to_jq(path, data):
+def to_jq(path, data) -> str:
+    """Return the JSON query given a path."""
     indices = path.get_indices()
     jq = ""
     is_array_index = False
@@ -171,9 +81,131 @@ def to_jq(path, data):
     return jq
 
 
+class JSONTreeStore(Gtk.TreeStore):
+    """A tree-like data structure that can be used with the JSONTreeView."""
+
+    def __init__(self):
+        super().__init__(str)
+        is_dark = Gtk.Settings.get_default().get_property(
+            "gtk-application-prefer-dark-theme"
+        )
+        if is_dark:
+            self.color_array = "#f9f06b"  # Yellow
+            self.color_type = "#ffbe6f"  # Orange
+            self.color_string = "#dc8add"  # Purple
+            self.color_number = "#f66151"  # Red
+            self.color_object = "#99c1f1"  # Blue
+            self.color_key = "#8ff0a4"  # Green
+        else:
+            self.color_array = "#e5a50a"  # Yellow
+            self.color_type = "#c64600"  # Orange
+            self.color_string = "#613583"  # Purple
+            self.color_number = "#a51d2d"  # Red
+            self.color_object = "#1a5fb4"  # Blue
+            self.color_key = "#26a269"  # Green
+
+    def walk_tree(self, data, parent=None) -> None:
+        if isinstance(data, list):
+            self._add_item(None, data, parent)
+        elif isinstance(data, dict):
+            for key in sorted(data):
+                self._add_item(key, data[key], parent)
+        else:
+            self._add_item(None, data, parent)
+
+    def _add_item(self, key, data, parent=None):
+        if isinstance(data, dict):
+            if key is not None:
+                obj = self.append(
+                    parent,
+                    [
+                        self._format_item(
+                            self.color_object, self.color_type, str(key), "{}"
+                        )
+                    ],
+                )
+                self.walk_tree(data, obj)
+            else:
+                self.walk_tree(data, parent)
+        elif isinstance(data, list):
+            item = self._format_item(
+                self.color_array, self.color_number, key, str(len(data))
+            )
+            arr = self.append(parent, [item])
+            for index in range(0, len(data)):
+                item = '<b><span foreground="{}">[</span></b><span foreground="{}">{}</span><b><span foreground="{}">]</span></b>'.format(
+                    self.color_type, self.color_number, str(index), self.color_type
+                )
+                self._add_item(None, data[index], self.append(arr, [item]))
+        elif isinstance(data, str):
+            if len(data) > 256:
+                data = data[0:255] + " <i>…</i> "
+                if key is not None:
+                    item = self._format_item(
+                        self.color_key, self.color_string, key, f'"{data}"'
+                    )
+                    self.append(parent, [item])
+                else:
+                    item = self._span(self.color_string, data)
+                    self.append(parent, [item])
+            else:
+                if key is not None:
+                    item = self._format_item(
+                        self.color_key, self.color_string, key, f'"{data}"'
+                    )
+                    self.append(parent, [item])
+                else:
+                    item = self._span(self.color_string, data)
+                    self.append(parent, [item])
+
+        elif isinstance(data, numbers.Real):
+            item = self._format_item(self.color_key, self.color_number, key, str(data))
+            self.append(parent, [item])
+        elif data is None:
+            item = '<span foreground="{}">{}</span> <span foreground="{}"><i>{}</i></span>'.format(
+                self.color_key, key, self.color_type, "null"
+            )
+            self.append(parent, [item])
+        else:
+            print(
+                "Warning: do not know how to format {} of type {}".format(str(data)),
+                data.__class__.__name__,
+            )
+            self.append(parent, [repr(data)])
+
+    def _format_item(self, color_key, color_value, key, value):
+        if key is None:
+            return '<span foreground="{}">[…]</span> <span foreground="{}">{}</span>'.format(
+                color_key, color_value, value
+            )
+        return '<span foreground="{}">"{}"</span>: <span foreground="{}">{}</span>'.format(
+            color_key, key, color_value, value
+        )
+
+    def _span(self, color, value):
+        return '<span foreground="{}">"{}"</span>'.format(color, value)
+
+
+class JSONTreeView(Gtk.TreeView):
+    """A widget for displaying JSON.
+    
+    Args:
+      title -- The column title."""
+
+    def __init__(self, title=None):
+        super().__init__()
+        cell = Gtk.CellRendererText()
+        self.column = Gtk.TreeViewColumn(title, cell, markup=0)
+        self.append_column(self.column)
+
+    def set_title(self, title: str) -> None:
+        """Set the column title."""
+        self.column.set_title(title)
+
+
 class JSONViewerWindow(Gtk.Window):
     def __init__(self):
-        Gtk.Window.__init__(self, title="JSON Viewer")
+        super().__init__(title="JSON Viewer")
         self.set_default_size(600, 400)
 
         self.clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
@@ -182,6 +214,17 @@ class JSONViewerWindow(Gtk.Window):
         self.label_info.set_selectable(True)
 
         self.data = None
+
+        raw_data = ""
+        from_stdin = not (sys.stdin.isatty())
+
+        if len(sys.argv) == 2:
+            raw_data = open(sys.argv[1]).read().strip()
+        elif from_stdin:
+            raw_data = sys.stdin.read().strip()
+
+        if raw_data and raw_data[0] == "(" and raw_data[-1] == ")":
+            raw_data = raw_data[1:-1]
 
         column_title = ""
 
@@ -208,49 +251,41 @@ class JSONViewerWindow(Gtk.Window):
         menuitem_file_open.connect("activate", self.open_callback)
         menu.append(menuitem_file_open)
 
-        self.model = Gtk.TreeStore(str)
+        self.model = JSONTreeStore()
         swintree = Gtk.ScrolledWindow()
         swinpath = Gtk.ScrolledWindow()
-        self.tree = Gtk.TreeView()
-        self.tree.set_model(self.model)
-        self.tree.connect("button-release-event", self.on_treeview_button_press_event)
-        cell = Gtk.CellRendererText()
+        self.treeview = JSONTreeView(column_title)
+        self.treeview.set_model(self.model)
+        self.treeview.connect(
+            "button-release-event", self.on_treeview_button_press_event
+        )
 
-        self.tvcol = Gtk.TreeViewColumn(column_title, cell, markup=0)
-
-        tree_selection = self.tree.get_selection()
+        tree_selection = self.treeview.get_selection()
         tree_selection.connect("changed", self.on_selection_changed)
-        self.tree.append_column(self.tvcol)
 
-        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+        box = Gtk.VBox()
         box.pack_start(menubar, False, False, 1)
         box.pack_start(swintree, True, True, 1)
         box.pack_start(swinpath, False, False, 1)
-        swintree.add(self.tree)
+        swintree.add(self.treeview)
         swinpath.add(self.label_info)
         self.add(box)
 
         if self.data:
-            walk_tree(self.data, self.model)
-
-    def tree_selection_to_jq(self, tree_selection):
-        (model, iter_current) = tree_selection.get_selected()
-        jq = ""
-        if iter_current:
-            path = model.get_path(iter_current)
-            jq = to_jq(path, self.data)
-        return jq
+            self.model.walk_tree(self.data)
 
     def copy_path_to_clipboard(self, menuitem):
-        tree_selection = self.tree.get_selection()
-        jq = self.tree_selection_to_jq(tree_selection)
+        tree_selection = self.treeview.get_selection()
+        jq = self._tree_selection_to_jq(tree_selection)
         self.clipboard.set_text(jq, -1)
 
     def parse_json(self, data):
         self.data = json.loads(data)
 
     def open_callback(self, action):
-        open_dialog = Gtk.FileChooserDialog(
+        filefilter = Gtk.FileFilter()
+        filefilter.add_pattern("*.json")
+        dialog = Gtk.FileChooserDialog(
             "Select a JSON file",
             self,
             Gtk.FileChooserAction.OPEN,
@@ -261,32 +296,30 @@ class JSONViewerWindow(Gtk.Window):
                 Gtk.ResponseType.ACCEPT,
             ),
         )
-        open_dialog.set_local_only(False)
-        open_dialog.set_modal(True)
-        open_dialog.connect("response", self.open_response_cb)
-        open_dialog.run()
-        open_dialog.destroy()
+        dialog.set_local_only(False)
+        dialog.set_filter(filefilter)
+        dialog.connect("response", self.open_response_cb)
+        dialog.run()
+        dialog.destroy()
 
-    def open_response_cb(self, open_dialog, response_id):
+    def open_response_cb(self, dialog, response_id):
         if response_id == Gtk.ResponseType.ACCEPT:
             try:
-                file = open_dialog.get_file()
+                file = dialog.get_file()
                 [success, content, etags] = file.load_contents(None)
                 if success:
                     self.parse_json(content.decode("utf-8"))
                     self.model.clear()
-                    walk_tree(self.data, self.model)
+                    self.model.walk_tree(self.data)
                     self.label_info.set_text("")
-                    self.tvcol.set_title(open_dialog.get_filename())
+                    self.treeview.set_title(dialog.get_filename())
                 else:
-                    raise ValueError(
-                        "Error while opening " + open_dialog.get_filename()
-                    )
+                    raise ValueError("Error while opening " + dialog.get_filename())
             except Exception as e:
                 self.label_info.set_text(str(e))
 
     def on_selection_changed(self, tree_selection):
-        jq = self.tree_selection_to_jq(tree_selection)
+        jq = self._tree_selection_to_jq(tree_selection)
         self.label_info.set_text(jq)
 
     def on_treeview_button_press_event(self, treeview, event):
@@ -294,22 +327,30 @@ class JSONViewerWindow(Gtk.Window):
             x = int(event.x)
             y = int(event.y)
             time = event.time
-            pthinfo = treeview.get_path_at_pos(x, y)
+            pathinfo = treeview.get_path_at_pos(x, y)
 
-            if pthinfo is not None:
-                path, col, cellx, celly = pthinfo
+            if pathinfo is not None:
+                path, col, cellx, celly = pathinfo
                 treeview.grab_focus()
                 treeview.set_cursor(path, col, 0)
 
-                self.contextual_menu = Gtk.Menu()
-                menuitem_copy_path = Gtk.MenuItem(label="Copy path to clipboard")
+                context_menu = Gtk.Menu()
+                menuitem_copy_path = Gtk.MenuItem(label="Copy Path to Clipboard")
                 menuitem_copy_path.connect("activate", self.copy_path_to_clipboard)
                 menuitem_copy_path.show()
-                self.contextual_menu.append(menuitem_copy_path)
+                context_menu.append(menuitem_copy_path)
 
-                self.contextual_menu.popup(None, None, None, event.button, time, 0)
+                context_menu.popup(None, None, None, event.button, time, 0)
                 return True
         return False
+
+    def _tree_selection_to_jq(self, tree_selection):
+        (model, iter_current) = tree_selection.get_selected()
+        jq = ""
+        if iter_current:
+            path = model.get_path(iter_current)
+            jq = to_jq(path, self.data)
+        return jq
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Refactor out the code from the Window into a separate Store and widget so now the window utilizes the store and the view widget, which better follows single-responsibility principle (SRP), separation of concerns, and allows the widget to be used independently of the window.

Limits the open dialog to files with the *.json file extension through a `Gtk.FileFilter`.
Renamed the variable `pthinfo` to `pathinfo`.
Renamed the variable `contextual_menu` to `context_menu`.
Renamed the variable `tree` to `treeview`.
Call `super().__init__` instead of `Gtk.Window.__init__`.
Call `Gtk.VBox()` instead of `Gtk.Box(orientation=Gtk.Orientation.VERTICAL)`.

Better follows GNOME HIG in the `Gtk.MenuItem` label by capitalizing each word.